### PR TITLE
fix: Rename variables order rule config param

### DIFF
--- a/docs/rules/terraform_variables_order.md
+++ b/docs/rules/terraform_variables_order.md
@@ -7,7 +7,7 @@ Recommends alphabetical order for variables.
 ```hcl
 rule "terraform_variables_order" {
   enabled = true
-  sort_required = false
+  group_required = false # Set to true if you want required variables to be sorted separately from the optional ones
 }
 ```
 

--- a/example/variables-grouped.tf
+++ b/example/variables-grouped.tf
@@ -1,0 +1,9 @@
+
+variable "b" {
+  type = string
+}
+
+variable "a" {
+  type = string
+  default = "a"
+}

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,8 @@
+
+variable "b" {
+  type = string
+}
+
+variable "a" {
+  type = string
+}

--- a/project/meta.go
+++ b/project/meta.go
@@ -3,7 +3,7 @@ package project
 import "fmt"
 
 // Version is ruleset version
-var Version string = "0.2.0"
+var Version string = "0.2.1"
 
 // ReferenceLink returns the rule reference link
 func ReferenceLink(name string) string {

--- a/rules/terraform_variables_order.go
+++ b/rules/terraform_variables_order.go
@@ -22,7 +22,7 @@ type TerraformVariablesOrderRule struct {
 }
 
 type TerraformVariablesOrderRuleConfig struct {
-	SortRequired bool `hclext:"sort_required"`
+	GroupRequired bool `hclext:"group_required"`
 }
 
 // NewTerraformVariablesOrderRule returns a new rule
@@ -63,10 +63,8 @@ func (r *TerraformVariablesOrderRule) Check(runner tflint.Runner) error {
 		return err
 	}
 
-	logger.Debug(fmt.Sprintf("value of sort_required: %v", config.SortRequired))
-
 	for _, file := range files {
-		if subErr := r.checkVariablesOrder(runner, config.SortRequired, file); subErr != nil {
+		if subErr := r.checkVariablesOrder(runner, config.GroupRequired, file); subErr != nil {
 			err = multierror.Append(err, subErr)
 		}
 	}
@@ -94,13 +92,8 @@ func (r *TerraformVariablesOrderRule) checkVariablesOrder(runner tflint.Runner, 
 
 	variableNames := r.getVariableNames(blocks)
 	if reflect.DeepEqual(variableNames, sortedVariableNames) {
-		logger.Debug("variables are sorted")
-		logger.Debug(fmt.Sprintf("variables: %v", variableNames))
 		return nil
 	}
-
-	logger.Debug("variables are not sorted")
-	logger.Debug(fmt.Sprintf("variables: %v", variableNames))
 
 	firstRange := r.firstVariableRange(blocks)
 	sortedVariableHclTxts := r.sortedVariableCodeTxts(blocks, file, sortedVariableNames)

--- a/rules/terraform_variables_order_test.go
+++ b/rules/terraform_variables_order_test.go
@@ -20,7 +20,7 @@ terraform{}`,
 			Config: `
 rule "terraform_variables_order" {
   enabled       = true
-  sort_required = true
+  group_required = true
 }`,
 			Expected: helper.Issues{},
 		},
@@ -53,7 +53,7 @@ variable "docker_ports" {
 			Config: `
 rule "terraform_variables_order" {
   enabled       = true
-  sort_required = true
+  group_required = true
 }`,
 			Expected: helper.Issues{},
 		},
@@ -71,7 +71,7 @@ variable "image_id" {
 			Config: `
 rule "terraform_variables_order" {
   enabled       = true
-  sort_required = true
+  group_required = true
 }`,
 			Expected: helper.Issues{
 				{
@@ -113,7 +113,7 @@ variable "availability_zone_names" {
 			Config: `
 rule "terraform_variables_order" {
   enabled       = true
-  sort_required = true
+  group_required = true
 }`,
 			Expected: helper.Issues{
 				{
@@ -170,7 +170,7 @@ variable "image_id" {
 			Config: `
 rule "terraform_variables_order" {
   enabled       = true
-  sort_required = true
+  group_required = true
 }`,
 			Expected: helper.Issues{
 				{
@@ -203,7 +203,7 @@ variable "docker_ports" {
 			},
 		},
 		{
-			Name: "6. sorting with sort_required disabled",
+			Name: "6. sorting with group_required disabled",
 			Content: `
 variable "availability_zone_names" {
   type    = list(string)
@@ -216,7 +216,7 @@ variable "image_id" {
 			Config: `
 rule "terraform_variables_order" {
   enabled       = true
-  sort_required = false
+  group_required = false
 }`,
 			Expected: helper.Issues{},
 		},


### PR DESCRIPTION
`sort_required` is confusing, changed to `group_required`